### PR TITLE
Made improvements for tag color command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BatchCommand.java
@@ -35,7 +35,7 @@ public class BatchCommand extends UndoableCommand {
         try {
             model.deletePersonsByTags(tagsToDelete);
         } catch (PersonNotFoundException e) {
-            assert false : "The target person cannot be missing";
+            throw new CommandException("The target person cannot be missing");
         }
 
         return new CommandResult(String.format(MESSAGE_BATCH_DELETE_SUCCESS, tagsToDelete));

--- a/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
@@ -40,7 +40,7 @@ public class ToggleTagColorCommand extends Command {
         model.resetData(model.getAddressBook());
 
         if (color == null) {
-            message = String.format("%s%s", MESSAGE_SUCCESS, "random".equals(tag)? "random" : "off");
+            message = String.format("%s%s", MESSAGE_SUCCESS, "random".equals(tag) ? "random" : "off");
         } else if (!(containsTag(model.getAddressBook().getTagList(), tag))) {
             message = NO_SUCH_TAG_MESSAGE;
         } else {

--- a/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
@@ -40,7 +40,7 @@ public class ToggleTagColorCommand extends Command {
         model.resetData(model.getAddressBook());
 
         if (color == null) {
-            message = String.format("%s%s", MESSAGE_SUCCESS, tag.equals("random") ? "random" : "off");
+            message = String.format("%s%s", MESSAGE_SUCCESS, "random".equals(tag)? "random" : "off");
         } else if (!(containsTag(model.getAddressBook().getTagList(), tag))) {
             message = NO_SUCH_TAG_MESSAGE;
         } else {

--- a/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ToggleTagColorCommand.java
@@ -14,18 +14,16 @@ public class ToggleTagColorCommand extends Command {
 
     public static final String COMMAND_WORD = "tagcolor";
     public static final String COMMAND_ALIAS = "tc";
-    public static final String MESSAGE_SUCCESS = "tagColor set to ";
+    public static final String MESSAGE_SUCCESS = "tag color set to ";
     public static final String NO_SUCH_TAG_MESSAGE = "No such tag";
 
     private final Logger logger = LogsCenter.getLogger(ToggleTagColorCommand.class);
 
-    private boolean toSet;
     private String tag;
     private String color;
     private String message;
 
-    public ToggleTagColorCommand(boolean toSet, String tag, String color) {
-        this.toSet = toSet;
+    public ToggleTagColorCommand(String tag, String color) {
         this.tag = tag;
         this.color = color;
     }
@@ -37,15 +35,16 @@ public class ToggleTagColorCommand extends Command {
      */
     @Override
     public CommandResult execute() throws CommandException {
-        model.setTagColor(toSet, tag, color);
+
+        model.setTagColor(tag, color);
         model.resetData(model.getAddressBook());
-        logger.fine(MESSAGE_SUCCESS + (toSet ? "random" : "off"));
-        if (!"".equals(tag) && !(containsTag(model.getAddressBook().getTagList(), tag))) {
+
+        if (color == null) {
+            message = String.format("%s%s", MESSAGE_SUCCESS, tag.equals("random") ? "random" : "off");
+        } else if (!(containsTag(model.getAddressBook().getTagList(), tag))) {
             message = NO_SUCH_TAG_MESSAGE;
-        } else if (tagCustomized(tag, color)) {
-            message = tag + " " + MESSAGE_SUCCESS + color;
         } else {
-            message = String.format("%s%s", MESSAGE_SUCCESS, toSet ? "random" : "off");
+            message = tag + " " + MESSAGE_SUCCESS + color;
         }
         return new CommandResult(message);
     }
@@ -59,16 +58,7 @@ public class ToggleTagColorCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ToggleTagColorCommand // instanceof handles nulls
-                && this.tag.equals(((ToggleTagColorCommand) other).tag))
-                && this.color.equals(((ToggleTagColorCommand) other).color)
-                && (this.toSet == (((ToggleTagColorCommand) other).toSet)); // state check
-    }
-
-    /**
-     * Returns true if user specified a tag string and color
-     */
-    private boolean tagCustomized(String tag, String color) {
-        return !"".equals(tag) && !"".equals(color);
+                && this.tag.equals(((ToggleTagColorCommand) other).tag)); // state check
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ToggleTagColorParser.java
+++ b/src/main/java/seedu/address/logic/parser/ToggleTagColorParser.java
@@ -21,25 +21,27 @@ public class ToggleTagColorParser implements Parser<ToggleTagColorCommand> {
 
     @Override
     public ToggleTagColorCommand parse(String userInput) throws ParseException {
-        boolean isOn;
+
         String cleanUserInput;
         cleanUserInput = userInput.trim();
         String[] args = cleanUserInput.split("\\s+");
         try {
-            switch (args[0]) {
-            case RANDOM_KEY_WORD:
-                isOn = true;
-                break;
-            case OFF_KEY_WORD:
-                isOn = false;
-                break;
-            default:
-                return new ToggleTagColorCommand(true, args[0], args[1]);
+            if (args.length == 1) {
+                switch (args[0]) {
+                case RANDOM_KEY_WORD:
+                    return new ToggleTagColorCommand(RANDOM_KEY_WORD, null);
+                case OFF_KEY_WORD:
+                    return new ToggleTagColorCommand(OFF_KEY_WORD, null);
+                default:
+                    throw new ParseException(MESSAGE_INVALID_COMMAND);
+                }
+            } else if (args.length == 2) {
+                return new ToggleTagColorCommand(args[0], args[1]);
             }
-            return new ToggleTagColorCommand(isOn, "", "");
         } catch (ArrayIndexOutOfBoundsException exp) {
             throw new ParseException(MESSAGE_INVALID_COMMAND);
         }
+        throw new ParseException(MESSAGE_INVALID_COMMAND);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ToggleTagColorParser.java
+++ b/src/main/java/seedu/address/logic/parser/ToggleTagColorParser.java
@@ -25,22 +25,19 @@ public class ToggleTagColorParser implements Parser<ToggleTagColorCommand> {
         String cleanUserInput;
         cleanUserInput = userInput.trim();
         String[] args = cleanUserInput.split("\\s+");
-        try {
-            if (args.length == 1) {
-                switch (args[0]) {
-                case RANDOM_KEY_WORD:
-                    return new ToggleTagColorCommand(RANDOM_KEY_WORD, null);
-                case OFF_KEY_WORD:
-                    return new ToggleTagColorCommand(OFF_KEY_WORD, null);
-                default:
-                    throw new ParseException(MESSAGE_INVALID_COMMAND);
-                }
-            } else if (args.length == 2) {
-                return new ToggleTagColorCommand(args[0], args[1]);
+        if (args.length == 1) {
+            switch (args[0]) {
+            case RANDOM_KEY_WORD:
+                return new ToggleTagColorCommand(RANDOM_KEY_WORD, null);
+            case OFF_KEY_WORD:
+                return new ToggleTagColorCommand(OFF_KEY_WORD, null);
+            default:
+                throw new ParseException(MESSAGE_INVALID_COMMAND);
             }
-        } catch (ArrayIndexOutOfBoundsException exp) {
-            throw new ParseException(MESSAGE_INVALID_COMMAND);
+        } else if (args.length == 2) {
+            return new ToggleTagColorCommand(args[0], args[1]);
         }
+
         throw new ParseException(MESSAGE_INVALID_COMMAND);
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -182,6 +182,9 @@ public class AddressBook implements ReadOnlyAddressBook {
             }
         }
 
+        if (toRemove.isEmpty()) {
+            throw new PersonNotFoundException();
+        }
         for (Person person : toRemove) {
             removePerson(person);
             removeUnusedTags(person.getTags());

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -58,8 +58,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         this.persons.setPersons(persons);
     }
 
-    public void setTags(Set<Tag> tags, boolean isOn, String tagString, String color) {
-        this.tags.setTags(tags, isOn, tagString, color);
+    public void setTags(Set<Tag> tags, String tagString, String color) {
+        this.tags.setTags(tags, tagString, color);
     }
 
     public void setTags(Set<Tag> tags) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -51,7 +51,7 @@ public interface Model {
     /**
      * Sets and updates the tag colors of a person
      */
-    void setTagColor(boolean toSet, String tag, String color);
+    void setTagColor(String tag, String color);
 
     /**
      * Deletes all persons in the {@code AddressBook} who have any of the {@code tags}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -90,9 +90,9 @@ public class ModelManager extends ComponentManager implements Model {
      * Updates UI by refreshing personListPanel
      */
     @Override
-    public synchronized void setTagColor(boolean isOn, String tagString, String color) {
+    public synchronized void setTagColor(String tagString, String color) {
         Set<Tag> tag = new HashSet<>(addressBook.getTagList());
-        addressBook.setTags(tag, isOn, tagString, color);
+        addressBook.setTags(tag, tagString, color);
         indicateAddressBookChanged();
     }
 

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -51,15 +51,23 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Replaces the Tags in this list with those in the argument tag list.
      */
-    public void setTags(Set<Tag> tags, boolean isOn, String tagString, String color) {
+    public void setTags(Set<Tag> tags, String tagString, String color) {
 
         requireAllNonNull(tags);
 
-        if (isOn) {
+        // If color is null, it means either tag color random or tag color off
+        // Else it means color is specified, and addressBook should assign a color to a tag
+
+        if (color == null) {
+            if ("random".equals(tagString)) {
+                setRandomColor(tags);
+            } else if ("off".equals(tagString)) {
+                setOffColor(tags);
+            }
+        } else {
             setColor(tags, tagString, color);
-        } else if (!isOn) {
-            setOffColor(tags);
         }
+
         assert CollectionUtil.elementsAreUnique(internalList);
         internalList.setAll(tags);
     }
@@ -76,14 +84,10 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     private void setColor(Set<Tag> tags, String tagString, String color) {
-        if (hasAssigned(tagString, color)) {
-            for (Tag tag : tags) {
-                if (tag.tagName.equals(tagString)) {
-                    tag.setColor(color);
-                }
+        for (Tag tag : tags) {
+            if (tag.tagName.equals(tagString)) {
+                tag.setColor(color);
             }
-        } else {
-            setRandomColor(tags);
         }
     }
 
@@ -91,9 +95,6 @@ public class UniqueTagList implements Iterable<Tag> {
         for (Tag tag : tags) {
             tag.setRandomColor();
         }
-    }
-    private boolean hasAssigned(String tagString, String color) {
-        return !"".equals(tagString) && !"".equals(color);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -144,7 +144,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setTagColor(boolean isOn, String tag, String color) {
+        public void setTagColor(String tag, String color) {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/address/logic/commands/BatchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BatchCommandTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.TypicalPersons;
+
+
+
+public class BatchCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void execute() throws IllegalValueException, CommandException {
+
+        Model model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+
+        Set<Tag> tagsToDelete = new HashSet<>();
+        BatchCommand command = new BatchCommand(tagsToDelete);
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        //Should not throw any error
+        try {
+            command.execute();
+        } catch (CommandException e) {
+            fail();
+        }
+
+        tagsToDelete.add(new Tag("nosuczhtag", "red"));
+
+        command = new BatchCommand(tagsToDelete);
+        command.setData(model, new CommandHistory(), new UndoRedoStack());
+
+        thrown.expect(CommandException.class);
+        command.execute();
+
+    }
+}
+

--- a/src/test/java/seedu/address/logic/commands/ToggleTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ToggleTagCommandTest.java
@@ -35,8 +35,8 @@ public class ToggleTagCommandTest {
     @Test
     public void equals() {
 
-        ToggleTagColorCommand testCommand = new ToggleTagColorCommand(true, "", "");
-        ToggleTagColorCommand testCommandTwo = new ToggleTagColorCommand(true, "", "");
+        ToggleTagColorCommand testCommand = new ToggleTagColorCommand("", "");
+        ToggleTagColorCommand testCommandTwo = new ToggleTagColorCommand("", "");
         //Test to ensure command is strictly a RemarkCommand
         assertFalse(testCommand.equals(new AddCommand(CARL)));
         assertFalse(testCommand.equals(new ClearCommand()));
@@ -56,41 +56,34 @@ public class ToggleTagCommandTest {
         assertFalse(testCommand == null);
         assertFalse(testCommandTwo == null);
 
-        //Test to check different booleans returns false
-        assertFalse(testCommand.equals(new ToggleTagColorCommand(false, "", "")));
-        assertFalse(testCommandTwo.equals(new ToggleTagColorCommand(false, "", "")));
-
         //Test to check different tag string returns false
-        assertFalse(testCommand.equals(new ToggleTagColorCommand(true, "aaa", "")));
-        assertFalse(testCommandTwo.equals(new ToggleTagColorCommand(true, "abc", "")));
+        assertFalse(testCommand.equals(new ToggleTagColorCommand("aaa", "")));
+        assertFalse(testCommandTwo.equals(new ToggleTagColorCommand("abc", "")));
 
-        //Test to check different color string returns false
-        assertFalse(testCommand.equals(new ToggleTagColorCommand(true, "", "aaa")));
-        assertFalse(testCommandTwo.equals(new ToggleTagColorCommand(true, "", "abc")));
     }
 
     @Test
     public void checkCommandResult() throws CommandException {
 
         //Check if the result message is correct when there is no tags found
-        ToggleTagColorCommand command = new ToggleTagColorCommand(true, "nosuchtag", "blue");
+        ToggleTagColorCommand command = new ToggleTagColorCommand("nosuchtag", "blue");
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         assertTrue(command.execute().feedbackToUser.equals("No such tag"));
 
         resetAddressBook();
 
         //When tag can be found in addressBook
-        command = new ToggleTagColorCommand(true, "friends", "blue");
+        command = new ToggleTagColorCommand("friends", "blue");
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         assertFalse(command.execute().feedbackToUser.equals("No such tag"));
-        assertTrue(command.execute().feedbackToUser.equals("friends tagColor set to blue"));
+        assertTrue(command.execute().feedbackToUser.equals("friends tag color set to blue"));
 
         resetAddressBook();
 
         //Check if friends tags are set to color
-        command = new ToggleTagColorCommand(true, "friends", "blue");
+        command = new ToggleTagColorCommand("friends", "blue");
         command.setData(model, new CommandHistory(), new UndoRedoStack());
-        assertTrue(command.execute().feedbackToUser.equals("friends tagColor set to blue"));
+        assertTrue(command.execute().feedbackToUser.equals("friends tag color set to blue"));
         for (Tag tag : model.getAddressBook().getTagList()) {
             if ("friends".equals(tag.tagName)) {
                 assertTrue(tag.getTagColor().equals("blue"));
@@ -99,26 +92,26 @@ public class ToggleTagCommandTest {
         }
 
         //Check if color tag will off properly
-        command = new ToggleTagColorCommand(false, "", "");
+        command = new ToggleTagColorCommand("off", null);
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         CommandResult commandResult = command.execute();
         for (Tag tag : model.getAddressBook().getTagList()) {
             assertTrue(tag.getTagColor().equals("grey"));
             assertFalse(tag.getTagColor().equals("blue"));
         }
-        assertTrue("tagColor set to off".equals(commandResult.feedbackToUser));
+        assertTrue("tag color set to off".equals(commandResult.feedbackToUser));
 
         //Check if color will set to random
-        command = new ToggleTagColorCommand(true, "", "");
+        command = new ToggleTagColorCommand("random", null);
         command.setData(model, new CommandHistory(), new UndoRedoStack());
         commandResult = command.execute();
-        assertTrue("tagColor set to random".equals(commandResult.feedbackToUser));
+        assertTrue("tag color set to random".equals(commandResult.feedbackToUser));
     }
 
     @Test
     public void checkNotNull() throws CommandException {
 
-        ToggleTagColorCommand command = new ToggleTagColorCommand(true, "nosuchtag", "blue");
+        ToggleTagColorCommand command = new ToggleTagColorCommand("nosuchtag", "blue");
         command.setData(model, new CommandHistory(), new UndoRedoStack());
 
         assertNotNull(command.execute());

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -70,7 +70,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommandToggleColor() throws ParseException {
         ToggleTagColorCommand command = (ToggleTagColorCommand) parser.parseCommand("tagcolor off");
-        assertEquals(new ToggleTagColorCommand(false, "", ""), command);
+        assertEquals(new ToggleTagColorCommand("off", null), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
@@ -19,9 +19,9 @@ public class ToggleTagColorParserTest {
 
         ToggleTagColorParser parser = new ToggleTagColorParser();
 
-        ToggleTagColorCommand expectedRandom = new ToggleTagColorCommand(true, "", "");
-        ToggleTagColorCommand expectedOff = new ToggleTagColorCommand(false, "", "");
-        ToggleTagColorCommand expectedDefault = new ToggleTagColorCommand(true, "Test", "Test2");
+        ToggleTagColorCommand expectedRandom = new ToggleTagColorCommand("random", null);
+        ToggleTagColorCommand expectedOff = new ToggleTagColorCommand("off", null);
+        ToggleTagColorCommand expectedDefault = new ToggleTagColorCommand("Test", "Test2");
 
 
         // Random keyword produces ToggleTagColorCommand(true, "", "")

--- a/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
@@ -35,6 +35,6 @@ public class ToggleTagColorParserTest {
 
         // Throw Parse error
         thrown.expect(ParseException.class);
-        parser.parse("Test");
+        parser.parse("tagcolor Test");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
@@ -35,6 +35,13 @@ public class ToggleTagColorParserTest {
 
         // Throw Parse error
         thrown.expect(ParseException.class);
-        parser.parse("tagcolor Test");
+        parser.parse("Test");
+    }
+
+    @Test
+    public void parseMoreThanTwoWords() throws Exception {
+        ToggleTagColorParser parser = new ToggleTagColorParser();
+        thrown.expect(ParseException.class);
+        parser.parse("This is longer than what is accepted");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ToggleTagColorParserTest.java
@@ -33,9 +33,8 @@ public class ToggleTagColorParserTest {
         // Default case produces ToggleTagColorCommand (true, "args[0]", "args[1]")
         assertTrue(parser.parse("Test Test2").equals(expectedDefault));
 
-        // Throw ArrayIndexOutOfBoundsException
+        // Throw Parse error
         thrown.expect(ParseException.class);
-
         parser.parse("Test");
     }
 }

--- a/src/test/java/seedu/address/model/UniqueTagListTest.java
+++ b/src/test/java/seedu/address/model/UniqueTagListTest.java
@@ -88,7 +88,7 @@ public class UniqueTagListTest {
         Set<Tag> tags = new HashSet<>(model.getAddressBook().getTagList());
 
         //Set all to random colors
-        uniqueTagList.setTags(tags, true, "", "");
+        uniqueTagList.setTags(tags, "random", null);
 
         for (Tag tag1 : tags) {
             assertFalse("grey".equals(tag1.getTagColor()));
@@ -99,7 +99,7 @@ public class UniqueTagListTest {
         Set<Tag> tags1 = new HashSet<>(model.getAddressBook().getTagList());
 
         //Set all to grey
-        uniqueTagList.setTags(tags1, false, "", "");
+        uniqueTagList.setTags(tags1, "off", null);
 
         for (Tag tag1 : tags) {
             assertTrue("grey".equals(tag1.getTagColor()));
@@ -110,7 +110,7 @@ public class UniqueTagListTest {
         Set<Tag> tags2 = new HashSet<>(model.getAddressBook().getTagList());
 
         //Set friends to blue
-        uniqueTagList.setTags(tags, true, "friends", "blue");
+        uniqueTagList.setTags(tags, "friends", "blue");
 
         for (Tag tagtest : tags2) {
             if ("friends".equals(tagtest.tagName)) {


### PR DESCRIPTION
Remove isOn as it is redundant.

If user type "tagcolor random blue"
the system will interpret it as the tag "random" will be set to blue

if user type "tagcolor random"
the system will interpret it as randomiize colors of all tags

Updated Test cases