### PR TITLE
Update UG to reflect Redo bug

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -320,6 +320,10 @@ You can reverse the most recent `undo` command. +
 image::redoexample.png[width="800"]
     Figure 11: Redo Command Usage Diagram
 
+[WARNING]
+Please do not input invalid dates/time. +
+You can refer to the following http://natty.joestelmach.com/doc.jsp[link] for the supported formats. +
+You can only set dates that are after current time. (i.e. You cannot set a time to yesterday) +
 // end::undoredo[]
 
 === Clearing all entries : `clear`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -321,9 +321,8 @@ image::redoexample.png[width="800"]
     Figure 11: Redo Command Usage Diagram
 
 [WARNING]
-Please do not input invalid dates/time. +
-You can refer to the following http://natty.joestelmach.com/doc.jsp[link] for the supported formats. +
-You can only set dates that are after current time. (i.e. You cannot set a time to yesterday) +
+*Known issue:* when `redo` is used on a modified list. +
+If you change the list after an `undo` (e.g. by using `duplicates`), and then use `redo`, `redo will `
 // end::undoredo[]
 
 === Clearing all entries : `clear`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -321,8 +321,10 @@ image::redoexample.png[width="800"]
     Figure 11: Redo Command Usage Diagram
 
 [WARNING]
-*Known issue:* when `redo` is used on a modified list. +
-If you change the list after an `undo` (e.g. by using `duplicates`), and then use `redo`, `redo will `
+*Known issue: when `redo` is used on a modified list.* +
+If you change the list after executing an `undo` command (e.g. by using `duplicates`),
+and then use `redo`, `redo` will not execute properly.
+Only use `redo` on lists which have not changed since using the `undo` command.
 // end::undoredo[]
 
 === Clearing all entries : `clear`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -323,8 +323,8 @@ image::redoexample.png[width="800"]
 [WARNING]
 *Known issue: when `redo` is used on a modified list.* +
 If you change the list after executing an `undo` command (e.g. by using `duplicates`),
-and then use `redo`, `redo` will not execute properly.
-Only use `redo` on lists which have not changed since using the `undo` command.
+and then use `redo`, `redo` will not execute properly. +
+Only use `redo` on lists which have not been modified since executing the `undo` command.
 // end::undoredo[]
 
 === Clearing all entries : `clear`


### PR DESCRIPTION
Full quote: 

[WARNING]
*Known issue: when `redo` is used on a modified list.*
If you change the list after executing an `undo` command (e.g. by using `duplicates`), and then use `redo`, `redo` will not execute properly.
Only use `redo` on lists which have not been modified since executing the `undo` command.